### PR TITLE
introduce caller reaction delay into the audio stream

### DIFF
--- a/src/messages.rs
+++ b/src/messages.rs
@@ -37,6 +37,8 @@ pub struct StationParams {
     pub frequency_offset_hz: f32,
     pub wpm: u8,
     pub amplitude: f32,
+    /// Delay in milliseconds before this station starts transmitting
+    pub reaction_delay_ms: u32,
 }
 
 /// Messages from UI thread to Audio thread

--- a/src/state.rs
+++ b/src/state.rs
@@ -207,9 +207,6 @@ pub enum ContestState {
 
     /// QSO complete, TU being sent or just sent
     QsoComplete,
-
-    /// Brief pause before tail-ender starts calling
-    WaitingForTailEnder,
 }
 
 impl ContestState {
@@ -259,7 +256,6 @@ impl ContestState {
                 }
             },
             ContestState::QsoComplete => ("QSO logged! Press F1 for next", StatusColor::Green),
-            ContestState::WaitingForTailEnder => ("QSO logged! Waiting...", StatusColor::Green),
         }
     }
 }
@@ -318,6 +314,7 @@ mod tests {
                 frequency_offset_hz: 0.0,
                 wpm: 25,
                 amplitude: 1.0,
+                reaction_delay_ms: 0,
             },
         };
 
@@ -329,6 +326,7 @@ mod tests {
                 frequency_offset_hz: 100.0,
                 wpm: 30,
                 amplitude: 0.8,
+                reaction_delay_ms: 0,
             },
         };
 


### PR DESCRIPTION
Callers already had a reaction delay, but it wasn't accounted for in the audio stream.  The effect was clear with multiple callers -- they all always started sending at exactly the same time.  The caller reaction delay is now propagated, and including in the audio generation.  I think this change makes the experience far more natural.

This realization came from a discussion with KD9UYC, who continues to help look for improvements.  Thank you, Mark!